### PR TITLE
Add Market Simulation Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "vercel": "yarn workspace @se-2/nextjs vercel",
     "vercel:login": "yarn workspace @se-2/nextjs vercel:login",
     "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo",
-    "verify": "yarn hardhat:verify"
+    "verify": "yarn hardhat:verify",
+    "simulator": "yarn workspace @se-2/hardhat simulator"
   },
   "devDependencies": {
     "husky": "~8.0.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vercel:login": "yarn workspace @se-2/nextjs vercel:login",
     "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo",
     "verify": "yarn hardhat:verify",
-    "simulator": "yarn workspace @se-2/hardhat simulator"
+    "simulate": "yarn workspace @se-2/hardhat simulate"
   },
   "devDependencies": {
     "husky": "~8.0.3",

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -54,6 +54,7 @@ const config: HardhatUserConfig = {
         url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
         enabled: process.env.MAINNET_FORKING_ENABLED === "true",
       },
+      gas: "auto",
     },
     mainnet: {
       url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -54,7 +54,6 @@ const config: HardhatUserConfig = {
         url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
         enabled: process.env.MAINNET_FORKING_ENABLED === "true",
       },
-      gas: "auto",
     },
     mainnet: {
       url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -18,7 +18,7 @@
     "lint-staged": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore",
     "test": "REPORT_GAS=true hardhat test --network hardhat",
     "verify": "hardhat etherscan-verify",
-    "simulator": "hardhat run scripts/marketSimulator.ts"
+    "simulate": "hardhat run scripts/marketSimulator.ts"
   },
   "dependencies": {
     "@inquirer/password": "^4.0.2",

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore ./*.ts ./deploy/**/*.ts ./scripts/**/*.ts ./test/**/*.ts",
     "lint-staged": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore",
     "test": "REPORT_GAS=true hardhat test --network hardhat",
-    "verify": "hardhat etherscan-verify"
+    "verify": "hardhat etherscan-verify",
+    "simulator": "hardhat run scripts/marketSimulator.ts"
   },
   "dependencies": {
     "@inquirer/password": "^4.0.2",

--- a/packages/hardhat/scripts/marketSimulator.ts
+++ b/packages/hardhat/scripts/marketSimulator.ts
@@ -64,7 +64,7 @@ async function simulateMarketActions(
   lending: BasicLending,
   corn: Corn,
   accounts: SimulatedAccount[],
-  deployer: any
+  deployer: any,
 ) {
   console.log("Starting market simulation...");
 
@@ -106,7 +106,6 @@ async function simulateMarketActions(
 
       // 5. Check for and perform liquidations
       await checkAndPerformLiquidations(lending, corn, accounts);
-
     } catch (error) {
       console.error("Error in market simulation interval");
       if (process.env.DEBUG) {
@@ -124,12 +123,12 @@ async function simulateBorrowing(lending: BasicLending, accounts: SimulatedAccou
   if (collateralValue <= 0n) return;
 
   const aggressiveBorrower = Math.random() < CHANCE_TO_BORROW;
-  
+
   // Calculate max borrow amount
-  const percentage = aggressiveBorrower ? 
-    85 + Math.random() * 14 : // Aggressive: 85-99%
-    30 + Math.random() * 40;  // Conservative: 30-70%
-  
+  const percentage = aggressiveBorrower
+    ? 85 + Math.random() * 14 // Aggressive: 85-99%
+    : 30 + Math.random() * 40; // Conservative: 30-70%
+
   const maxBorrowAmount = (collateralValue * BigInt(Math.floor(percentage * 10))) / 1000n;
 
   if (maxBorrowAmount > 0n) {
@@ -137,8 +136,8 @@ async function simulateBorrowing(lending: BasicLending, accounts: SimulatedAccou
       await lendingWithAccount.borrowCorn(maxBorrowAmount);
       console.log(
         `Account ${randomAccount.wallet.address} borrowed ${ethers.formatEther(maxBorrowAmount)} CORN ` +
-        `(${aggressiveBorrower ? "aggressive" : "conservative"}, ` +
-        `${((Number(maxBorrowAmount) * 100) / Number(collateralValue)).toFixed(1)}% of collateral)`
+          `(${aggressiveBorrower ? "aggressive" : "conservative"}, ` +
+          `${((Number(maxBorrowAmount) * 100) / Number(collateralValue)).toFixed(1)}% of collateral)`,
       );
     } catch (error) {
       if (process.env.DEBUG) {

--- a/packages/hardhat/scripts/marketSimulator.ts
+++ b/packages/hardhat/scripts/marketSimulator.ts
@@ -2,10 +2,15 @@ import { HDNodeWallet, parseEther } from "ethers";
 import hre from "hardhat";
 import { CornDEX, BasicLending, Corn, MovePrice } from "../typechain-types";
 const ethers = hre.ethers;
+
 interface SimulatedAccount {
   wallet: HDNodeWallet;
   initialEth: bigint;
 }
+
+const NUM_ACCOUNTS = 5;
+const CHANCE_TO_BORROW = 0.3;
+const CHANCE_TO_ADD_COLLATERAL = 0.2;
 
 const liquidationInProgress = new Set<string>();
 
@@ -29,24 +34,6 @@ async function fundAccountsIfNeeded(accounts: SimulatedAccount[], deployer: any)
   }
 }
 
-async function simulatePeriodicFunding(accounts: SimulatedAccount[], deployer: any) {
-  console.log("Starting periodic funding checker...");
-
-  ethers.provider.on("block", async blockNumber => {
-    try {
-      // Check every 10 blocks
-      if (blockNumber % 10 === 0) {
-        await fundAccountsIfNeeded(accounts, deployer);
-      }
-    } catch (error) {
-      console.error(`Error in periodic funding at block ${blockNumber}`);
-      if (process.env.DEBUG) {
-        console.error(error);
-      }
-    }
-  });
-}
-
 async function setupAccounts(): Promise<SimulatedAccount[]> {
   console.log("Setting up simulated accounts...");
 
@@ -58,7 +45,7 @@ async function setupAccounts(): Promise<SimulatedAccount[]> {
   const baseMnemonic = "test test test test test test test test test test test junk";
 
   // Create 5 deterministic wallets
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < NUM_ACCOUNTS; i++) {
     const wallet = ethers.HDNodeWallet.fromPhrase(baseMnemonic, `m/44'/60'/0'/0/${i}`).connect(ethers.provider);
     accounts.push({
       wallet,
@@ -72,298 +59,222 @@ async function setupAccounts(): Promise<SimulatedAccount[]> {
   return accounts;
 }
 
-async function movePrice(movePrice: MovePrice) {
-  console.log("Starting price oracle simulator...");
+async function simulateMarketActions(
+  movePrice: MovePrice,
+  lending: BasicLending,
+  corn: Corn,
+  accounts: SimulatedAccount[],
+  deployer: any
+) {
+  console.log("Starting market simulation...");
 
-  let trend = Math.random() > 0.5 ? 1 : -1; // Start with random trend
+  let trend = Math.random() > 0.5 ? 1 : -1;
   let trendDuration = 0;
-  let maxTrendDuration = Math.floor(Math.random() * 13) + 5; // Random duration between 5-17 blocks
+  let maxTrendDuration = Math.floor(Math.random() * 8) + 7;
 
-  ethers.provider.on("block", async blockNumber => {
+  // Run market actions every 2 seconds
+  setInterval(async () => {
     try {
-      // Increment trend duration
+      // 1. Update price
       trendDuration++;
-
-      // Maybe switch trend direction
       if (trendDuration >= maxTrendDuration) {
-        trend *= -1; // Reverse trend
+        trend *= -1;
         trendDuration = 0;
-        maxTrendDuration = Math.floor(Math.random() * 10) + 5; // New random duration
-        console.log(`Block ${blockNumber}: Trend reversed to ${trend > 0 ? "upward" : "downward"}`);
+        maxTrendDuration = Math.floor(Math.random() * 8) + 7;
+        console.log(`Trend reversed to ${trend > 0 ? "upward" : "downward"}`);
       }
 
-      // Add some noise to the trend
       const noise = Math.random() * 2.5 - 1.6;
       const direction = trend + noise;
-
       const amount = parseEther("24000");
       const amountToSell = direction > 0 ? amount : -amount * 1000n;
 
-      const tx = await movePrice.movePrice(amountToSell);
-      await tx.wait();
+      await movePrice.movePrice(amountToSell);
+
+      // 2. Check and fund accounts if needed
+      await fundAccountsIfNeeded(accounts, deployer);
+
+      // 3. Random borrowing (30% chance)
+      if (Math.random() < CHANCE_TO_BORROW) {
+        await simulateBorrowing(lending, accounts);
+      }
+
+      // 4. Random collateral addition (20% chance)
+      if (Math.random() < CHANCE_TO_ADD_COLLATERAL) {
+        await simulateAddCollateral(lending, accounts);
+      }
+
+      // 5. Check for and perform liquidations
+      await checkAndPerformLiquidations(lending, corn, accounts);
+
     } catch (error) {
-      console.error(`Error updating price at block ${blockNumber}`);
+      console.error("Error in market simulation interval");
       if (process.env.DEBUG) {
         console.error(error);
       }
     }
-  });
+  }, 2000); // 2 second interval
 }
 
 async function simulateBorrowing(lending: BasicLending, accounts: SimulatedAccount[]) {
-  console.log("Starting random borrowing simulator...");
+  const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
+  const lendingWithAccount = lending.connect(randomAccount.wallet);
 
-  ethers.provider.on("block", async blockNumber => {
+  const collateralValue = await lending.calculateCollateralValue(randomAccount.wallet.address);
+  if (collateralValue <= 0n) return;
+
+  const aggressiveBorrower = Math.random() < CHANCE_TO_BORROW;
+  
+  // Calculate max borrow amount
+  const percentage = aggressiveBorrower ? 
+    85 + Math.random() * 14 : // Aggressive: 85-99%
+    30 + Math.random() * 40;  // Conservative: 30-70%
+  
+  const maxBorrowAmount = (collateralValue * BigInt(Math.floor(percentage * 10))) / 1000n;
+
+  if (maxBorrowAmount > 0n) {
     try {
-      // 20% chance each block that a random account will try to borrow
-      if (Math.random() < 0.3) {
-        const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
-        const lendingWithAccount = lending.connect(randomAccount.wallet);
-
-        const collateralValue = await lending.calculateCollateralValue(randomAccount.wallet.address);
-        if (collateralValue > 0n) {
-          const aggressiveBorrower = Math.random() < 0.3;
-
-          // Calculate max borrow amount based on collateral
-          let maxBorrowAmount: bigint;
-          if (aggressiveBorrower) {
-            // Aggressive: 85-99% of collateral
-            const percentage = 85 + Math.random() * 14;
-            maxBorrowAmount = (collateralValue * BigInt(Math.floor(percentage * 10))) / 1000n;
-          } else {
-            // Conservative: 30-70% of collateral
-            const percentage = 30 + Math.random() * 40;
-            maxBorrowAmount = (collateralValue * BigInt(Math.floor(percentage * 10))) / 1000n;
-          }
-
-          if (maxBorrowAmount > 0n) {
-            try {
-              await lendingWithAccount.borrowCorn(maxBorrowAmount);
-              console.log(
-                `Account ${randomAccount.wallet.address} borrowed ${ethers.formatEther(maxBorrowAmount)} CORN ` +
-                  `(${aggressiveBorrower ? "aggressive" : "conservative"}, ` +
-                  `${((Number(maxBorrowAmount) * 100) / Number(collateralValue)).toFixed(1)}% of collateral)`,
-              );
-            } catch (error) {
-              // Silently fail if borrowing not possible
-              if (process.env.DEBUG) {
-                console.error(error);
-              }
-            }
-          }
-        }
-      }
+      await lendingWithAccount.borrowCorn(maxBorrowAmount);
+      console.log(
+        `Account ${randomAccount.wallet.address} borrowed ${ethers.formatEther(maxBorrowAmount)} CORN ` +
+        `(${aggressiveBorrower ? "aggressive" : "conservative"}, ` +
+        `${((Number(maxBorrowAmount) * 100) / Number(collateralValue)).toFixed(1)}% of collateral)`
+      );
     } catch (error) {
-      console.error(`Error in random borrowing at block ${blockNumber}`);
       if (process.env.DEBUG) {
         console.error(error);
       }
     }
-  });
-}
-
-async function simulateLiquidator(lending: BasicLending, corn: Corn, accounts: SimulatedAccount[]) {
-  console.log("Starting liquidator bot...");
-
-  const cornDEX = await ethers.getContract<CornDEX>("CornDEX");
-
-  ethers.provider.on("block", async blockNumber => {
-    try {
-      // Get all historical AddCollateral events to find users
-      const filter = lending.filters.CollateralAdded();
-      const events = await lending.queryFilter(filter);
-      const users = [...new Set(events.map(event => event.args[0]))];
-
-      // Check each user's position
-      for (const user of users) {
-        // Skip if already being liquidated
-        if (liquidationInProgress.has(user.toLowerCase())) continue;
-
-        const amountBorrowed = await lending.s_userBorrowed(user);
-        if (amountBorrowed === 0n) continue;
-
-        const isLiquidatable = await lending.isLiquidatable(user);
-        if (!isLiquidatable) continue;
-
-        // Find eligible liquidators
-        const eligibleLiquidators = [];
-        for (const account of accounts) {
-          // Skip if this is the user being checked
-          if (account.wallet.address.toLowerCase() === user.toLowerCase()) continue;
-
-          const liquidatorBalance = await corn.balanceOf(account.wallet.address);
-          if (liquidatorBalance >= amountBorrowed) {
-            eligibleLiquidators.push(account);
-          }
-        }
-
-        // If no eligible liquidators, try to swap ETH for CORN using a random account
-        if (eligibleLiquidators.length === 0) {
-          const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
-          if (randomAccount.wallet.address.toLowerCase() !== user.toLowerCase()) {
-            const cornDEXWithAccount = cornDEX.connect(randomAccount.wallet);
-
-            // Calculate how much ETH we need to swap to get enough CORN
-            const currentPrice = await cornDEX.currentPrice();
-            // Add 10% buffer for price impact and slippage
-            const ethNeeded = (amountBorrowed * currentPrice * 110n) / (1000n * parseEther("1"));
-            const balance = await ethers.provider.getBalance(randomAccount.wallet.address);
-            const maxETHPossible = ethNeeded > balance ? balance - ethers.parseEther("0.1") : ethNeeded;
-            if (maxETHPossible < ethers.parseEther("0.01")) continue;
-            try {
-              const swapTx = await cornDEXWithAccount.swap(maxETHPossible, {
-                value: maxETHPossible,
-              });
-              await swapTx.wait();
-
-              // Verify the swap gave enough CORN
-              const newBalance = await corn.balanceOf(randomAccount.wallet.address);
-              if (newBalance >= amountBorrowed) {
-                eligibleLiquidators.push(randomAccount);
-                console.log(
-                  `Account ${randomAccount.wallet.address} swapped ${ethers.formatEther(ethNeeded)} ETH for CORN`,
-                );
-              }
-            } catch (error) {
-              console.error(`Failed to swap ETH for CORN`);
-              if (process.env.DEBUG) {
-                console.error(error);
-              }
-            }
-          }
-        }
-
-        // Randomly select one of the eligible liquidators
-        const liquidator = eligibleLiquidators[Math.floor(Math.random() * eligibleLiquidators.length)];
-        if (!liquidator) continue;
-
-        // Mark user as being liquidated
-        liquidationInProgress.add(user.toLowerCase());
-        console.log(`Account ${liquidator.wallet.address} found liquidatable position for user: ${user}`);
-
-        const lendingWithLiquidator = lending.connect(liquidator.wallet);
-        const cornWithLiquidator = corn.connect(liquidator.wallet);
-
-        try {
-          const approveTx = await cornWithLiquidator.approve(lending.target, amountBorrowed);
-          await approveTx.wait();
-
-          const tx = await lendingWithLiquidator.liquidate(user);
-          await tx.wait();
-
-          const balance = await ethers.provider.getBalance(user);
-          const twoETH = parseEther("2");
-          if (balance > twoETH) {
-            await lendingWithLiquidator.addCollateral({ value: balance - twoETH });
-          }
-
-          console.log(`Successfully liquidated position for user ${user} at block ${blockNumber}`);
-        } catch (error) {
-          console.error(`Failed to liquidate user ${user}`);
-          if (process.env.DEBUG) {
-            console.error(error);
-          }
-        } finally {
-          liquidationInProgress.delete(user.toLowerCase());
-        }
-
-        // Only liquidate one position per block
-        break;
-      }
-    } catch (error) {
-      console.error(`Error in liquidator at block ${blockNumber}`);
-      if (process.env.DEBUG) {
-        console.error(error);
-      }
-    }
-  });
+  }
 }
 
 async function simulateAddCollateral(lending: BasicLending, accounts: SimulatedAccount[]) {
-  console.log("Starting random collateral simulator...");
+  const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
+  const lendingWithAccount = lending.connect(randomAccount.wallet);
 
-  ethers.provider.on("block", async blockNumber => {
-    try {
-      // 15% chance each block that a random account will add collateral
-      if (Math.random() < 0.2) {
-        const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
-        const lendingWithAccount = lending.connect(randomAccount.wallet);
+  const balance = await ethers.provider.getBalance(randomAccount.wallet.address);
+  const currentCollateral = await lending.s_userCollateral(randomAccount.wallet.address);
 
-        // Get current balance and collateral
+  if (balance > ethers.parseEther("3")) {
+    const maxPossible = balance - ethers.parseEther("2"); // Keep 2 ETH for operations
+    const percentage = 20 + Math.random() * 60;
+    const amountToAdd = (maxPossible * BigInt(Math.floor(percentage * 10))) / 1000n;
+
+    if (amountToAdd > ethers.parseEther("0.1")) {
+      try {
+        const tx = await lendingWithAccount.addCollateral({ value: amountToAdd });
+        await tx.wait();
+
+        console.log(
+          `Account ${randomAccount.wallet.address} added ${ethers.formatEther(amountToAdd)} ETH as collateral ` +
+            `(${percentage.toFixed(1)}% of available balance, ` +
+            `total collateral: ${ethers.formatEther(currentCollateral + amountToAdd)} ETH)`,
+        );
+      } catch (error) {
+        if (process.env.DEBUG) {
+          console.error(error);
+        }
+      }
+    }
+  }
+}
+
+async function checkAndPerformLiquidations(lending: BasicLending, corn: Corn, accounts: SimulatedAccount[]) {
+  const cornDEX = await ethers.getContract<CornDEX>("CornDEX");
+
+  const filter = lending.filters.CollateralAdded();
+  const events = await lending.queryFilter(filter);
+  const users = [...new Set(events.map(event => event.args[0]))];
+
+  for (const user of users) {
+    if (liquidationInProgress.has(user.toLowerCase())) continue;
+
+    const amountBorrowed = await lending.s_userBorrowed(user);
+    if (amountBorrowed === 0n) continue;
+
+    const isLiquidatable = await lending.isLiquidatable(user);
+    if (!isLiquidatable) continue;
+
+    const eligibleLiquidators = accounts.filter(account => account.wallet.address.toLowerCase() !== user.toLowerCase());
+
+    if (eligibleLiquidators.length === 0) {
+      const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
+      if (randomAccount.wallet.address.toLowerCase() !== user.toLowerCase()) {
+        const cornDEXWithAccount = cornDEX.connect(randomAccount.wallet);
+
+        const currentPrice = await cornDEX.currentPrice();
+        const ethNeeded = (amountBorrowed * currentPrice * 110n) / (1000n * parseEther("1"));
         const balance = await ethers.provider.getBalance(randomAccount.wallet.address);
-        const currentCollateral = await lending.s_userCollateral(randomAccount.wallet.address);
+        const maxETHPossible = ethNeeded > balance ? balance - ethers.parseEther("0.1") : ethNeeded;
+        if (maxETHPossible < ethers.parseEther("0.01")) continue;
+        try {
+          const swapTx = await cornDEXWithAccount.swap(maxETHPossible, {
+            value: maxETHPossible,
+          });
+          await swapTx.wait();
 
-        // Only proceed if account has more than 3 ETH (keep some for gas)
-        if (balance > ethers.parseEther("3")) {
-          // Calculate a random amount to add as collateral
-          const maxPossible = balance - ethers.parseEther("2"); // Keep 2 ETH for operations
-
-          // Random percentage of available ETH (20-80%)
-          const percentage = 20 + Math.random() * 60;
-          const amountToAdd = (maxPossible * BigInt(Math.floor(percentage * 10))) / 1000n;
-
-          if (amountToAdd > ethers.parseEther("0.1")) {
-            try {
-              const tx = await lendingWithAccount.addCollateral({ value: amountToAdd });
-              await tx.wait();
-
-              console.log(
-                `Account ${randomAccount.wallet.address} added ${ethers.formatEther(amountToAdd)} ETH as collateral ` +
-                  `(${percentage.toFixed(1)}% of available balance, ` +
-                  `total collateral: ${ethers.formatEther(currentCollateral + amountToAdd)} ETH)`,
-              );
-            } catch (error) {
-              // Silently fail if transaction fails
-              if (process.env.DEBUG) {
-                console.error(error);
-              }
-            }
+          const newBalance = await corn.balanceOf(randomAccount.wallet.address);
+          if (newBalance >= amountBorrowed) {
+            liquidationInProgress.add(user.toLowerCase());
+            console.log(
+              `Account ${randomAccount.wallet.address} swapped ${ethers.formatEther(ethNeeded)} ETH for CORN`,
+            );
+          }
+        } catch (error) {
+          console.error(`Failed to swap ETH for CORN`);
+          if (process.env.DEBUG) {
+            console.error(error);
           }
         }
       }
+    }
+
+    const liquidator = eligibleLiquidators[Math.floor(Math.random() * eligibleLiquidators.length)];
+    if (!liquidator) continue;
+
+    liquidationInProgress.add(user.toLowerCase());
+    console.log(`Account ${liquidator.wallet.address} found liquidatable position for user: ${user}`);
+
+    const lendingWithLiquidator = lending.connect(liquidator.wallet);
+    const cornWithLiquidator = corn.connect(liquidator.wallet);
+
+    try {
+      const approveTx = await cornWithLiquidator.approve(lending.target, amountBorrowed);
+      await approveTx.wait();
+
+      const tx = await lendingWithLiquidator.liquidate(user);
+      await tx.wait();
+
+      const balance = await ethers.provider.getBalance(user);
+      const twoETH = parseEther("2");
+      if (balance > twoETH) {
+        await lendingWithLiquidator.addCollateral({ value: balance - twoETH });
+      }
+
+      console.log(`Successfully liquidated position for user ${user}`);
     } catch (error) {
-      console.error(`Error in random collateral at block ${blockNumber}`);
+      console.error(`Failed to liquidate user ${user}`);
       if (process.env.DEBUG) {
         console.error(error);
       }
+    } finally {
+      liquidationInProgress.delete(user.toLowerCase());
     }
-  });
-}
 
-async function disableAutomine() {
-  // Disable automine
-  await ethers.provider.send("evm_setAutomine", [false]);
-  await ethers.provider.send("evm_setIntervalMining", [2000]);
-  console.log("Set to mine blocks every 2 seconds");
+    break;
+  }
 }
 
 async function main() {
-  // Initial setup
   const [deployer] = await ethers.getSigners();
   const movePriceContract = await ethers.getContract<MovePrice>("MovePrice", deployer);
   const lending = await ethers.getContract<BasicLending>("BasicLending", deployer);
   const corn = await ethers.getContract<Corn>("Corn", deployer);
 
-  // Setup accounts
   const accounts = await setupAccounts();
 
-  // Disable automine now that accounts are set up
-  await disableAutomine();
-
-  // Start oracle price simulation
-  await movePrice(movePriceContract);
-
-  // Start liquidator bot with accounts
-  await simulateLiquidator(lending, corn, accounts);
-
-  // Start random borrowing simulation
-  await simulateBorrowing(lending, accounts);
-
-  // Start random collateral additions
-  await simulateAddCollateral(lending, accounts);
-
-  // Start periodic funding checks
-  await simulatePeriodicFunding(accounts, deployer);
+  // Start the combined market simulation
+  await simulateMarketActions(movePriceContract, lending, corn, accounts, deployer);
 
   // Keep the script running
   process.stdin.resume();

--- a/packages/hardhat/scripts/marketSimulator.ts
+++ b/packages/hardhat/scripts/marketSimulator.ts
@@ -1,0 +1,348 @@
+import { HDNodeWallet, parseEther } from "ethers";
+import hre from "hardhat";
+import { CornDEX, BasicLending, Corn, MovePrice } from "../typechain-types";
+const ethers = hre.ethers;
+interface SimulatedAccount {
+  wallet: HDNodeWallet;
+  initialEth: bigint;
+}
+
+const liquidationInProgress = new Set<string>();
+
+async function fundAccountsIfNeeded(accounts: SimulatedAccount[], deployer: any) {
+  for (const account of accounts) {
+    const currentBalance = await ethers.provider.getBalance(account.wallet.address);
+    
+    // Fund if balance drops below 2 ETH
+    if (currentBalance < ethers.parseEther("2")) {
+      // Random amount between 3-13 ETH
+      const randomEth = 3 + Math.random() * 10;
+      const topUpAmount = ethers.parseEther(randomEth.toString());
+      
+      const tx = await deployer.sendTransaction({
+        to: account.wallet.address,
+        value: topUpAmount,
+      });
+      await tx.wait();
+      console.log(`Topped up ${account.wallet.address} with ${randomEth.toFixed(2)} ETH`);
+    }
+  }
+}
+
+async function simulatePeriodicFunding(accounts: SimulatedAccount[], deployer: any) {
+  console.log("Starting periodic funding checker...");
+
+  ethers.provider.on("block", async blockNumber => {
+    try {
+      // Check every 10 blocks
+      if (blockNumber % 10 === 0) {
+        await fundAccountsIfNeeded(accounts, deployer);
+      }
+    } catch (error) {
+      console.error(`Error in periodic funding at block ${blockNumber}`);
+    }
+  });
+}
+
+async function setupAccounts(lending: BasicLending, corn: Corn): Promise<SimulatedAccount[]> {
+  console.log("Setting up simulated accounts...");
+
+  const accounts: SimulatedAccount[] = [];
+  const initialEth = ethers.parseEther("12"); // 12 ETH each
+  const [deployer] = await ethers.getSigners();
+
+  // Create deterministic wallets using a base mnemonic
+  const baseMnemonic = "test test test test test test test test test test test junk";
+
+  // Create 5 deterministic wallets
+  for (let i = 0; i < 5; i++) {
+    const wallet = ethers.HDNodeWallet.fromPhrase(baseMnemonic, `m/44'/60'/0'/0/${i}`).connect(ethers.provider);
+    accounts.push({
+      wallet,
+      initialEth,
+    });
+  }
+
+  // Do initial funding
+  await fundAccountsIfNeeded(accounts, deployer);
+
+
+  return accounts;
+}
+
+async function movePrice(movePrice: MovePrice) {
+  console.log("Starting price oracle simulator...");
+
+  let trend = Math.random() > 0.5 ? 1 : -1; // Start with random trend
+  let trendDuration = 0;
+  let maxTrendDuration = Math.floor(Math.random() * 13) + 5; // Random duration between 5-17 blocks
+
+  ethers.provider.on("block", async blockNumber => {
+    try {
+      // Increment trend duration
+      trendDuration++;
+
+      // Maybe switch trend direction
+      if (trendDuration >= maxTrendDuration) {
+        trend *= -1; // Reverse trend
+        trendDuration = 0;
+        maxTrendDuration = Math.floor(Math.random() * 10) + 5; // New random duration
+        console.log(`Block ${blockNumber}: Trend reversed to ${trend > 0 ? 'upward' : 'downward'}`);
+      }
+
+      // Add some noise to the trend
+      const noise = (Math.random() * 2.5 - 1.6);
+      const direction = trend + noise;
+      
+      const amount = parseEther("24000");
+      const amountToSell = direction > 0 ? amount : -amount * 1000n;
+  
+      const tx = await movePrice.movePrice(amountToSell);
+      await tx.wait();
+
+    } catch (error) {
+      console.error(`Error updating price at block ${blockNumber}:`, error);
+    }
+  });
+}
+
+async function simulateBorrowing(lending: BasicLending, accounts: SimulatedAccount[]) {
+  console.log("Starting random borrowing simulator...");
+
+  ethers.provider.on("block", async blockNumber => {
+    try {
+      // 20% chance each block that a random account will try to borrow
+      if (Math.random() < 0.30) {
+        const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
+        const lendingWithAccount = lending.connect(randomAccount.wallet);
+
+        const collateralValue = await lending.calculateCollateralValue(randomAccount.wallet.address);
+        if (collateralValue > 0n) {
+          const aggressiveBorrower = Math.random() < 0.3;
+          
+          // Calculate max borrow amount based on collateral
+          let maxBorrowAmount: bigint;
+          if (aggressiveBorrower) {
+            // Aggressive: 85-99% of collateral
+            const percentage = 85 + Math.random() * 14;
+            maxBorrowAmount = (collateralValue * BigInt(Math.floor(percentage * 10))) / 1000n;
+          } else {
+            // Conservative: 30-70% of collateral
+            const percentage = 30 + Math.random() * 40;
+            maxBorrowAmount = (collateralValue * BigInt(Math.floor(percentage * 10))) / 1000n;
+          }
+          
+          if (maxBorrowAmount > 0n) {
+            try {
+              await lendingWithAccount.borrowCorn(maxBorrowAmount);
+              console.log(
+                `Account ${randomAccount.wallet.address} borrowed ${ethers.formatEther(maxBorrowAmount)} CORN ` +
+                `(${aggressiveBorrower ? 'aggressive' : 'conservative'}, ` +
+                `${((Number(maxBorrowAmount) * 100) / Number(collateralValue)).toFixed(1)}% of collateral)`
+              );
+            } catch (error) {
+              // Silently fail if borrowing not possible
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error in random borrowing at block ${blockNumber}:`, error);
+    }
+  });
+}
+
+async function simulateLiquidator(lending: BasicLending, corn: Corn, accounts: SimulatedAccount[]) {
+  console.log("Starting liquidator bot...");
+
+  const cornDEX = await ethers.getContract<CornDEX>("CornDEX");
+
+  ethers.provider.on("block", async blockNumber => {
+    try {
+      // Get all historical AddCollateral events to find users
+      const filter = lending.filters.CollateralAdded();
+      const events = await lending.queryFilter(filter);
+      const users = [...new Set(events.map(event => event.args[0]))];
+
+      // Check each user's position
+      for (const user of users) {
+        // Skip if already being liquidated
+        if (liquidationInProgress.has(user.toLowerCase())) continue;
+
+        const amountBorrowed = await lending.s_userBorrowed(user);
+        if (amountBorrowed === 0n) continue;
+        
+        const isLiquidatable = await lending.isLiquidatable(user);
+        if (!isLiquidatable) continue;
+
+        // Find eligible liquidators
+        const eligibleLiquidators = [];
+        for (const account of accounts) {
+          // Skip if this is the user being checked
+          if (account.wallet.address.toLowerCase() === user.toLowerCase()) continue;
+
+          const liquidatorBalance = await corn.balanceOf(account.wallet.address);
+          if (liquidatorBalance >= amountBorrowed) {
+            eligibleLiquidators.push(account);
+          }
+        }
+
+        // If no eligible liquidators, try to swap ETH for CORN using a random account
+        if (eligibleLiquidators.length === 0) {
+          const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
+          if (randomAccount.wallet.address.toLowerCase() !== user.toLowerCase()) {
+            const cornDEXWithAccount = cornDEX.connect(randomAccount.wallet);
+            
+            // Calculate how much ETH we need to swap to get enough CORN
+            const currentPrice = await cornDEX.currentPrice();
+            // Add 10% buffer for price impact and slippage
+            const ethNeeded = (amountBorrowed * currentPrice * 110n) / (1000n * parseEther("1"));
+            const balance = await ethers.provider.getBalance(randomAccount.wallet.address);
+            const maxETHPossible = ethNeeded > balance ? balance - ethers.parseEther("0.1") : ethNeeded;
+            if (maxETHPossible < ethers.parseEther("0.01")) continue;
+            try {
+              const swapTx = await cornDEXWithAccount.swap(maxETHPossible, { 
+                value: maxETHPossible 
+              });
+              await swapTx.wait();
+              
+              // Verify the swap gave enough CORN
+              const newBalance = await corn.balanceOf(randomAccount.wallet.address);
+              if (newBalance >= amountBorrowed) {
+                eligibleLiquidators.push(randomAccount);
+                console.log(`Account ${randomAccount.wallet.address} swapped ${ethers.formatEther(ethNeeded)} ETH for CORN`);
+              }
+            } catch (error) {
+              console.error(`Failed to swap ETH for CORN`);
+            }
+          }
+        }
+
+        // Randomly select one of the eligible liquidators
+        const liquidator = eligibleLiquidators[Math.floor(Math.random() * eligibleLiquidators.length)];
+        if (!liquidator) continue;
+
+        // Mark user as being liquidated
+        liquidationInProgress.add(user.toLowerCase());
+        console.log(`Account ${liquidator.wallet.address} found liquidatable position for user: ${user}`);
+
+        const lendingWithLiquidator = lending.connect(liquidator.wallet);
+        const cornWithLiquidator = corn.connect(liquidator.wallet);
+
+        try {
+          const approveTx = await cornWithLiquidator.approve(lending.target, amountBorrowed);
+          await approveTx.wait();
+
+          const tx = await lendingWithLiquidator.liquidate(user);
+          await tx.wait();
+
+          const balance = await ethers.provider.getBalance(user);
+          const twoETH = parseEther("2");
+          if (balance > twoETH) {
+            await lendingWithLiquidator.addCollateral({ value: balance - twoETH });
+          }
+
+          console.log(`Successfully liquidated position for user ${user} at block ${blockNumber}`);
+        } catch (error) {
+          console.error(`Failed to liquidate user ${user}`);
+        } finally {
+          liquidationInProgress.delete(user.toLowerCase());
+        }
+
+        // Only liquidate one position per block
+        break;
+      }
+    } catch (error) {
+      console.error(`Error in liquidator at block ${blockNumber}`);
+    }
+  });
+}
+
+async function simulateAddCollateral(lending: BasicLending, accounts: SimulatedAccount[]) {
+  console.log("Starting random collateral simulator...");
+
+  ethers.provider.on("block", async blockNumber => {
+    try {
+      // 15% chance each block that a random account will add collateral
+      if (Math.random() < 0.20) {
+        const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
+        const lendingWithAccount = lending.connect(randomAccount.wallet);
+
+        // Get current balance and collateral
+        const balance = await ethers.provider.getBalance(randomAccount.wallet.address);
+        const currentCollateral = await lending.s_userCollateral(randomAccount.wallet.address);
+        
+        // Only proceed if account has more than 3 ETH (keep some for gas)
+        if (balance > ethers.parseEther("3")) {
+          // Calculate a random amount to add as collateral
+          const maxPossible = balance - ethers.parseEther("2"); // Keep 2 ETH for operations
+          
+          // Random percentage of available ETH (20-80%)
+          const percentage = 20 + Math.random() * 60;
+          const amountToAdd = (maxPossible * BigInt(Math.floor(percentage * 10))) / 1000n;
+
+          if (amountToAdd > ethers.parseEther("0.1")) {
+            try {
+              const tx = await lendingWithAccount.addCollateral({ value: amountToAdd });
+              await tx.wait();
+              
+              console.log(
+                `Account ${randomAccount.wallet.address} added ${ethers.formatEther(amountToAdd)} ETH as collateral ` +
+                `(${percentage.toFixed(1)}% of available balance, ` +
+                `total collateral: ${ethers.formatEther(currentCollateral + amountToAdd)} ETH)`
+              );
+            } catch (error) {
+              // Silently fail if transaction fails
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error in random collateral at block ${blockNumber}`);
+    }
+  });
+}
+
+async function disableAutomine() {
+  // Disable automine
+  await ethers.provider.send("evm_setAutomine", [false]);
+  await ethers.provider.send("evm_setIntervalMining", [2000]);
+  console.log("Set to mine blocks every 2 seconds");
+}
+
+async function main() {
+  // Initial setup
+  const [deployer] = await ethers.getSigners();
+  const movePriceContract = await ethers.getContract<MovePrice>("MovePrice", deployer);
+  const lending = await ethers.getContract<BasicLending>("BasicLending", deployer);
+  const corn = await ethers.getContract<Corn>("Corn", deployer);
+
+  // Setup accounts
+  const accounts = await setupAccounts(lending, corn);
+
+  // Disable automine now that accounts are set up
+  await disableAutomine();
+
+  // Start oracle price simulation
+  await movePrice(movePriceContract);
+
+  // Start liquidator bot with accounts
+  await simulateLiquidator(lending, corn, accounts);
+
+  // Start random borrowing simulation
+  await simulateBorrowing(lending, accounts);
+
+  // Start random collateral additions
+  await simulateAddCollateral(lending, accounts);
+
+  // Start periodic funding checks
+  await simulatePeriodicFunding(accounts, deployer);
+
+  // Keep the script running
+  process.stdin.resume();
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/nextjs/app/_components/PriceActions.tsx
+++ b/packages/nextjs/app/_components/PriceActions.tsx
@@ -13,8 +13,14 @@ const PriceActions = () => {
 
   const { writeContractAsync } = useScaffoldWriteContract({ contractName: "MovePrice" });
 
+  const priceOfOneCORN = price ? parseEther((1 / Number(formatEther(price))).toString()) : undefined; // Fixed parentheses and added toString()
   const renderPrice =
-    price === undefined ? <div className="mr-1 skeleton w-10 h-4"></div> : Number(formatEther(price)).toFixed(2);
+    priceOfOneCORN === undefined ? (
+      <div className="mr-1 skeleton w-10 h-4"></div>
+    ) : (
+      Number(formatEther(priceOfOneCORN)).toFixed(6)
+    );
+  const renderETHPrice = price ? Number(formatEther(price)).toFixed(2) : <div className="mr-1 skeleton w-10 h-4"></div>;
 
   const handleClick = async (isIncrease: boolean) => {
     if (price === undefined) {
@@ -22,7 +28,7 @@ const PriceActions = () => {
       return;
     }
     const amount = parseEther("50000");
-    const amountToSell = !isIncrease ? amount : -amount * 1000n;
+    const amountToSell = isIncrease ? amount : -amount * 1000n;
 
     try {
       await writeContractAsync({
@@ -39,11 +45,10 @@ const PriceActions = () => {
       <div className="w-[150px] py-5 flex flex-col items-center gap-2 indicator">
         <TooltipInfo top={3} right={3} infoText="Use these controls to simulate price changes" />
         <div className="flex items-center gap-1">
-          <span className="text-sm">CORN Price</span>
+          <span className="text-sm font-bold">{tokenName} Price</span>
         </div>
-        <span className="flex items-center text-xs">
-          {renderPrice} {tokenName} / ETH
-        </span>
+        <span className="flex items-center text-xs">{renderPrice} ETH</span>
+        <span className="flex items-center text-xs">{renderETHPrice} CORN/ETH</span>
         <div className="flex gap-2">
           <button onClick={() => handleClick(false)} className="btn btn-circle btn-xs">
             <MinusIcon className="h-3 w-3" />

--- a/packages/nextjs/app/_components/TokenActions.tsx
+++ b/packages/nextjs/app/_components/TokenActions.tsx
@@ -32,6 +32,7 @@ const TokenActions = () => {
       <div className="w-[150px] py-5 flex flex-col items-center gap-1 indicator">
         <TooltipInfo top={3} right={3} infoText={`Here you can send ${tokenName} to any address or swap it`} />
         <div className="flex flex-col items-center gap-1">
+          <span className="text-sm font-bold">{tokenName} Wallet</span>
           <span className="text-sm">
             {tokenBalance} {tokenName}
           </span>


### PR DESCRIPTION
Basically run `yarn simulate` after `yarn chain` and `yarn deploy` to watch accounts spin up and perform all the actions along with moving the price of CORN each block (every 2 seconds).

Now revised to not set a specific block time. This way the user experience is pretty normal and not slowed down at all.